### PR TITLE
feat: TypeScript enum 직접 지원 기능 추가

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   buildKeywordKey,
   buildKeywordMap,
   getKeywordLabel,
+  enumToDefinitions,
 } from "./core/prefixEnum.js";
 
 export type {

--- a/tests/buildKeywordMap.test.ts
+++ b/tests/buildKeywordMap.test.ts
@@ -164,4 +164,59 @@ describe("buildKeywordMap", () => {
     expect(map2["CATEGORY1_ITEM1"]?.label).toBe("Item 1");
     expect(map2["CATEGORY2_ITEM2"]?.label).toBe("Item 2");
   });
+
+  describe("TypeScript enum 지원", () => {
+    enum SmokingEnum {
+      TRYING_TO_QUIT = "TRYING_TO_QUIT",
+      NEVER = "NEVER",
+    }
+
+    enum DrinkingEnum {
+      TRYING_TO_QUIT = "TRYING_TO_QUIT",
+      NEVER = "NEVER",
+    }
+
+    it("enumGroups 객체에 TypeScript enum을 직접 전달할 수 있다", () => {
+      const map = buildKeywordMap({
+        SMOKING: SmokingEnum,
+        DRINKING: DrinkingEnum,
+      });
+
+      // enum 값이 라벨로 사용됨
+      expect(map["SMOKING_TRYING_TO_QUIT"]?.label).toBe("TRYING_TO_QUIT");
+      expect(map["SMOKING_NEVER"]?.label).toBe("NEVER");
+      expect(map["DRINKING_TRYING_TO_QUIT"]?.label).toBe("TRYING_TO_QUIT");
+      expect(map["DRINKING_NEVER"]?.label).toBe("NEVER");
+      expect(Object.keys(map)).toHaveLength(4);
+    });
+
+    it("enumGroups 객체에 enum과 일반 객체를 함께 사용할 수 있다", () => {
+      const map = buildKeywordMap({
+        SMOKING: SmokingEnum,
+        STATUS: {
+          active: "Active",
+          inactive: "Inactive",
+        },
+      });
+
+      // enum 값이 라벨로 사용됨
+      expect(map["SMOKING_TRYING_TO_QUIT"]?.label).toBe("TRYING_TO_QUIT");
+      expect(map["STATUS_ACTIVE"]?.label).toBe("Active");
+      expect(map["STATUS_INACTIVE"]?.label).toBe("Inactive");
+    });
+
+    it("enumGroups 객체에 enum과 options를 함께 전달할 수 있다", () => {
+      const map = buildKeywordMap(
+        {
+          TEST: SmokingEnum,
+        },
+        {
+          formatLabel: (value) => `Custom: ${value}`,
+        },
+      );
+
+      expect(map["TEST_TRYING_TO_QUIT"]?.label).toBe("Custom: TRYING_TO_QUIT");
+      expect(map["TEST_NEVER"]?.label).toBe("Custom: NEVER");
+    });
+  });
 });

--- a/tests/enumToDefinitions.test.ts
+++ b/tests/enumToDefinitions.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { enumToDefinitions } from "../src/core/prefixEnum.js";
+
+// TypeScript enum 정의
+enum StringEnum {
+  TRYING_TO_QUIT = "TRYING_TO_QUIT",
+  NEVER = "NEVER",
+  SOMETIMES = "SOMETIMES",
+}
+
+enum NumericEnum {
+  ACTIVE = 0,
+  INACTIVE = 1,
+  PENDING = 2,
+}
+
+enum MixedEnum {
+  FIRST = "first",
+  SECOND = 2,
+  THIRD = "third",
+}
+
+describe("enumToDefinitions", () => {
+  it("문자열 enum을 KeywordDefinition 객체로 변환한다", () => {
+    const result = enumToDefinitions(StringEnum);
+
+    expect(result).toEqual({
+      TRYING_TO_QUIT: "TRYING_TO_QUIT",
+      NEVER: "NEVER",
+      SOMETIMES: "SOMETIMES",
+    });
+  });
+
+  it("숫자 enum을 KeywordDefinition 객체로 변환한다", () => {
+    const result = enumToDefinitions(NumericEnum);
+
+    expect(result).toEqual({
+      ACTIVE: "0",
+      INACTIVE: "1",
+      PENDING: "2",
+    });
+  });
+
+  it("혼합 enum을 KeywordDefinition 객체로 변환한다", () => {
+    const result = enumToDefinitions(MixedEnum);
+
+    expect(result).toEqual({
+      FIRST: "first",
+      SECOND: "2",
+      THIRD: "third",
+    });
+  });
+
+  it("숫자 enum의 역방향 매핑을 제외한다", () => {
+    const result = enumToDefinitions(NumericEnum);
+
+    // 숫자 키(0, 1, 2)는 제외되어야 함
+    expect(result["0"]).toBeUndefined();
+    expect(result["1"]).toBeUndefined();
+    expect(result["2"]).toBeUndefined();
+
+    // 문자열 키만 포함되어야 함
+    expect(result["ACTIVE"]).toBe("0");
+    expect(result["INACTIVE"]).toBe("1");
+    expect(result["PENDING"]).toBe("2");
+  });
+
+  it("빈 enum을 처리한다", () => {
+    enum EmptyEnum {}
+    const result = enumToDefinitions(EmptyEnum);
+
+    expect(result).toEqual({});
+  });
+});

--- a/tests/prefixEnum.test.ts
+++ b/tests/prefixEnum.test.ts
@@ -99,4 +99,68 @@ describe("prefixEnum", () => {
     expect(result.labelMap["STATUS_ACTIVE"]).toBe("Active");
     expect(result.labelMap["STATUS_INACTIVE"]).toBe("Inactive");
   });
+
+  describe("TypeScript enum 지원", () => {
+    enum SmokingEnum {
+      TRYING_TO_QUIT = "TRYING_TO_QUIT",
+      NEVER = "NEVER",
+      SOMETIMES = "SOMETIMES",
+    }
+
+    enum StatusEnum {
+      ACTIVE = 0,
+      INACTIVE = 1,
+      PENDING = 2,
+    }
+
+    it("문자열 enum을 직접 받아 처리한다", () => {
+      const result = prefixEnum("SMOKING", SmokingEnum);
+
+      expect(result.category).toBe("SMOKING");
+      expect(result.keys.TRYING_TO_QUIT).toBe("SMOKING_TRYING_TO_QUIT");
+      expect(result.keys.NEVER).toBe("SMOKING_NEVER");
+      expect(result.keys.SOMETIMES).toBe("SMOKING_SOMETIMES");
+      // enum 값이 라벨로 사용됨
+      expect(result.map["SMOKING_TRYING_TO_QUIT"]?.label).toBe("TRYING_TO_QUIT");
+      expect(result.map["SMOKING_NEVER"]?.label).toBe("NEVER");
+    });
+
+    it("숫자 enum을 직접 받아 처리한다", () => {
+      const result = prefixEnum("STATUS", StatusEnum);
+
+      expect(result.category).toBe("STATUS");
+      expect(result.keys.ACTIVE).toBe("STATUS_ACTIVE");
+      expect(result.keys.INACTIVE).toBe("STATUS_INACTIVE");
+      expect(result.keys.PENDING).toBe("STATUS_PENDING");
+      // enum 값이 라벨로 사용됨
+      expect(result.map["STATUS_ACTIVE"]?.label).toBe("0");
+      expect(result.map["STATUS_INACTIVE"]?.label).toBe("1");
+    });
+
+    it("enum에 formatLabel 옵션을 적용할 수 있다", () => {
+      const result = prefixEnum("SMOKING", SmokingEnum, {
+        formatLabel: (value) => `Custom: ${value}`,
+      });
+
+      expect(result.map["SMOKING_TRYING_TO_QUIT"]?.label).toBe("Custom: TRYING_TO_QUIT");
+      expect(result.map["SMOKING_NEVER"]?.label).toBe("Custom: NEVER");
+    });
+
+    it("enum에서도 중복 키를 감지한다", () => {
+      // enum의 경우 키 이름을 value로 사용하므로, 같은 값이어도 키 이름이 다르면 다른 키가 됨
+      // 실제 중복은 같은 키 이름을 가진 경우에만 발생
+      enum DuplicateEnum {
+        SAME_KEY = "same_value",
+        SAME_KEY2 = "same_value", // 같은 값이지만 키 이름이 다름
+      }
+
+      // 키 이름을 value로 사용하므로 SAME_KEY와 SAME_KEY2는 다른 키가 됨
+      const result = prefixEnum("TEST", DuplicateEnum);
+      expect(result.keys.SAME_KEY).toBe("TEST_SAME_KEY");
+      expect(result.keys.SAME_KEY2).toBe("TEST_SAME_KEY2");
+
+      // 실제 중복은 같은 키 이름을 가진 경우에만 발생
+      // enum에서는 키 이름이 다르면 중복이 아님
+    });
+  });
 });


### PR DESCRIPTION
## 📝 개요

객체 enum/배열 enum/const enum 모두 지원 중 `TypeScript enum` 직접 지원 기능을 구현합니다. 라이브러리 목표에서 enum 지원을 명시했지만, 실제로는 객체 형태의 정의만 지원하여 TypeScript enum을 사용하는 사용자가 추가 변환 단계를 거쳐야 했습니다. 이는 사용자 경험을 저하시키고 코드 중복을 유발했습니다. 이 문제를 해결하기 위해 사용자가 TypeScript enum을 객체로 변환하지 않고도 직접 `prefixEnum`과 `buildKeywordMap`에 전달할 수 있도록 개선했습니다.

- #6 

### 개선 사항

**TypeScript enum 직접 지원:**
- `enumToDefinitions` 함수 추가로 TypeScript enum을 `KeywordDefinition` 객체로 자동 변환
- `prefixEnum`에 enum을 직접 받는 오버로드 추가로 enum을 객체로 변환할 필요 없음
- `buildKeywordMap`의 enumGroups 객체에 enum을 직접 전달 가능
- 문자열 enum, 숫자 enum, 혼합 enum 모두 지원
- 숫자 enum의 역방향 매핑 자동 제외
- formatLabel 옵션도 enum에 적용 가능

이러한 개선을 통해 사용자는 TypeScript enum을 더 직관적이고 타입 안전한 방식으로 사용할 수 있게 되었습니다.

---

## 🔄 변경 사항 요약

| 구분 | 변경 내용 | 영향 범위 |
| --- | --- | --- |
| **새 함수 추가** | `enumToDefinitions` 함수 추가 | `src/core/prefixEnum.ts` |
| **API 확장** | `prefixEnum`에 enum 오버로드 추가 | `src/core/prefixEnum.ts` |
| **기능 개선** | `buildKeywordMap`에서 enum 직접 전달 지원 | `src/core/prefixEnum.ts` |
| **Export 추가** | `enumToDefinitions` export 추가 | `src/index.ts` |
| **테스트 추가** | enum 지원 기능에 대한 테스트 추가 | `tests/` |

---

## ✅ 구현 상세

### 1. `enumToDefinitions` 함수

#### 기능

TypeScript enum을 `KeywordDefinition` 객체로 변환하는 유틸리티 함수입니다.

```typescript
export const enumToDefinitions = <T extends Record<string, string | number>>(
  enumObject: T,
): Record<string, KeywordDefinition> => {
  const result: Record<string, KeywordDefinition> = {};

  for (const key in enumObject) {
    // 숫자 enum의 역방향 매핑 제외
    if (isNaN(Number(key))) {
      const value = enumObject[key];
      if (typeof value === "string" || typeof value === "number") {
        result[key] = String(value);
      }
    }
  }

  return result;
};
```

**특징:**
- 숫자 enum의 역방향 매핑 자동 제외
- 문자열 enum, 숫자 enum, 혼합 enum 모두 지원
- enum 값을 문자열로 변환하여 라벨로 사용

#### 사용 예시

```typescript
enum SmokingEnum {
  TRYING_TO_QUIT = "TRYING_TO_QUIT",
  NEVER = "NEVER",
}

const definitions = enumToDefinitions(SmokingEnum);
// → { TRYING_TO_QUIT: "TRYING_TO_QUIT", NEVER: "NEVER" }
```

---

### 2. `prefixEnum` 오버로드 추가

#### 함수 시그니처

```typescript
/**
 * TypeScript enum을 직접 받아 prefixEnum 실행
 */
export function prefixEnum<T extends Record<string, string | number>>(
  category: string,
  enumObject: T,
  options?: PrefixEnumOptions,
): PrefixEnumResult<string>;

/**
 * 객체 형태의 정의를 받아 prefixEnum 실행
 */
export function prefixEnum<const TName extends string>(
  category: string,
  definitions: Record<TName, KeywordDefinition>,
  options?: PrefixEnumOptions,
): PrefixEnumResult<TName>;
```

#### 구현 로직

```typescript
export function prefixEnum<const TName extends string>(
  category: string,
  definitionsOrEnum: Record<TName, KeywordDefinition> | Record<string, string | number>,
  options: PrefixEnumOptions = {},
): PrefixEnumResult<TName> {
  // enum인지 확인: 모든 값이 string 또는 number인 경우 enum으로 간주
  let definitions: Record<string, KeywordDefinition>;
  let isEnumType = false;

  if (Object.keys(definitionsOrEnum).length > 0) {
    const isEnum = Object.values(definitionsOrEnum).every(
      (v) => typeof v === "string" || typeof v === "number",
    );

    if (isEnum) {
      definitions = enumToDefinitions(definitionsOrEnum as Record<string, string | number>);
      isEnumType = true;
    } else {
      definitions = definitionsOrEnum as Record<TName, KeywordDefinition>;
    }
  }

  // enum인 경우: 키 이름을 value로 사용
  // 일반 객체인 경우: 기존 로직
  const valueToNormalize = isEnumType
    ? name
    : typeof definition === "string"
      ? name
      : (definition.value ?? name);

  // enum인 경우: formatLabel 옵션이 있으면 적용, 없으면 enum 값을 라벨로 사용
  const label = isEnumType
    ? options.formatLabel
      ? formatLabel(normalizedValue, name)
      : typeof definition === "string"
        ? definition
        : formatLabel(normalizedValue, name)
    : typeof definition === "string"
      ? definition
      : (definition.label ?? formatLabel(normalizedValue, name));
}
```

**핵심 설계 결정:**
- 타입 가드로 enum과 일반 객체를 자동 구분
- enum의 경우 키 이름을 value로 사용하여 고유 키 생성
- formatLabel 옵션이 있으면 적용, 없으면 enum 값을 라벨로 사용

#### 사용 예시

```typescript
// 문자열 enum
enum SmokingEnum {
  TRYING_TO_QUIT = "TRYING_TO_QUIT",
  NEVER = "NEVER",
}

const result = prefixEnum("SMOKING", SmokingEnum);
// result.map["SMOKING_TRYING_TO_QUIT"]?.label → "TRYING_TO_QUIT"

// 숫자 enum
enum StatusEnum {
  ACTIVE = 0,
  INACTIVE = 1,
}

const result = prefixEnum("STATUS", StatusEnum);
// result.map["STATUS_ACTIVE"]?.label → "0"

// formatLabel 옵션 적용
const result = prefixEnum("SMOKING", SmokingEnum, {
  formatLabel: (value) => `Custom: ${value}`,
});
// result.map["SMOKING_TRYING_TO_QUIT"]?.label → "Custom: TRYING_TO_QUIT"
```

---

### 3. `buildKeywordMap` enum 지원

#### 개선 내용

`buildKeywordMap`의 enumGroups 객체에 TypeScript enum을 직접 전달할 수 있도록 지원합니다.

```typescript
enum SmokingEnum {
  TRYING_TO_QUIT = "TRYING_TO_QUIT",
  NEVER = "NEVER",
}

enum DrinkingEnum {
  TRYING_TO_QUIT = "TRYING_TO_QUIT",
  NEVER = "NEVER",
}

// enum을 직접 전달 가능
const map = buildKeywordMap({
  SMOKING: SmokingEnum,
  DRINKING: DrinkingEnum,
});

// enum과 일반 객체 함께 사용 가능
const map = buildKeywordMap({
  SMOKING: SmokingEnum,
  STATUS: {
    active: "Active",
    inactive: "Inactive",
  },
});

// enum과 options 함께 전달
const map = buildKeywordMap(
  {
    TEST: SmokingEnum,
  },
  {
    formatLabel: (value) => `Custom: ${value}`,
  },
);
```

---

## 🧪 테스트

### 테스트 커버리지

| 기능 | 테스트 케이스 | 파일 |
| --- | --- | --- |
| **enumToDefinitions** | 문자열 enum, 숫자 enum, 혼합 enum, 역방향 매핑 제외, 빈 enum | `tests/enumToDefinitions.test.ts` |
| **prefixEnum enum 지원** | 문자열 enum, 숫자 enum, formatLabel 옵션, 중복 키 처리 | `tests/prefixEnum.test.ts` |
| **buildKeywordMap enum 지원** | enumGroups에 enum 직접 전달, enum과 일반 객체 함께 사용, enum과 options 함께 전달 | `tests/buildKeywordMap.test.ts` |

**테스트 결과:** ✅ 모든 테스트 통과 (50개)

### 주요 테스트 시나리오

#### `enumToDefinitions` 테스트
- ✅ 문자열 enum 변환
- ✅ 숫자 enum 변환
- ✅ 혼합 enum 변환
- ✅ 숫자 enum의 역방향 매핑 제외
- ✅ 빈 enum 처리

#### `prefixEnum` enum 지원 테스트
- ✅ 문자열 enum 직접 처리
- ✅ 숫자 enum 직접 처리
- ✅ formatLabel 옵션 적용
- ✅ enum 중복 키 처리 (enum은 키 이름을 value로 사용)

#### `buildKeywordMap` enum 지원 테스트
- ✅ enumGroups 객체에 enum 직접 전달
- ✅ enum과 일반 객체 함께 사용
- ✅ enum과 options 함께 전달

---

## 📊 변경 파일

| 파일 | 변경 내용 | 라인 수 |
| --- | --- | --- |
| `src/core/prefixEnum.ts` | `enumToDefinitions` 함수 추가, `prefixEnum` 오버로드 추가, enum 처리 로직 개선 | +113 |
| `src/index.ts` | `enumToDefinitions` export 추가 | +1 |
| `tests/enumToDefinitions.test.ts` | `enumToDefinitions` 테스트 추가 (신규 파일) | +74 |
| `tests/prefixEnum.test.ts` | TypeScript enum 지원 테스트 추가 | +64 |
| `tests/buildKeywordMap.test.ts` | TypeScript enum 지원 테스트 추가 | +55 |

---

## ✅ 체크리스트

- [x] `enumToDefinitions` 함수 구현
- [x] `prefixEnum`에 enum 오버로드 추가
- [x] enum 자동 감지 로직 구현
- [x] 숫자 enum 역방향 매핑 제외 처리
- [x] formatLabel 옵션 enum 지원
- [x] `buildKeywordMap`에서 enum 직접 전달 지원
- [x] 모든 테스트 케이스 작성 및 통과
- [x] 타입 안전성 확보

---

## 📝 참고

- TypeScript enum은 런타임에 객체로 존재하므로 접근 가능
- const enum은 컴파일 타임에 인라인되어 런타임 객체 접근 불가 (현재 미지원)
- 숫자 enum의 역방향 매핑은 자동으로 제외됨
- enum 값이 라벨로 사용되며, formatLabel 옵션으로 커스터마이징 가능
- 모든 기존 테스트 통과 확인
- 타입 체크 및 린트 통과

